### PR TITLE
Add new docker build instructions for the bot

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,12 @@
+DISCORD_BOT_TOKEN=$TOKEN # Bot token from the Discord developer portal
+DISCORD_BOT_LANGUAGE=$LANGUAGE # Bot language (key from translations.json)
+DISCORD_BOT_PREFIXES=$PREFIXES # Bot commands prefixes
+
+G5API_URL=$APIURL # Make sure this is API url, not the front-end
+G5V_URL=$FRONTENDURL # Front-end url
+
+POSTGRESQL_USER=$SQLUSER # PostgreSQL user name
+POSTGRESQL_PASSWORD=$SQLPASSWORD # PostgreSQL password
+POSTGRESQL_DB=$DATABASE # PostgreSQL Database
+POSTGRESQL_HOST=$SQLHOST # PostgreSQL host
+POSTGRESQL_PORT=$SQLPORT

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,41 @@
+name: publish to ghcr
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  push:
+    name: "Create build and push to GHCR"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          buildkitd-flags: --debug
+      - id: string
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ github.repository_owner }}
+      - uses: actions/checkout@v2
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          push: true
+          tags: |
+            ghcr.io/${{ steps.string.outputs.lowercase }}/g5bot:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3-alpine
+
+RUN apk add libpq-dev build-base gettext jpeg-dev zlib-dev
+
+WORKDIR /G5Bot
+COPY . .
+RUN pip3 install -r requirements.txt
+
+CMD ls -la
+CMD envsubst < /G5Bot/.env.template > /G5Bot/.env && \
+    python3 migrate.py up && \
+    python3 launcher.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.7"
+
+services:
+  g5botdb:
+    image: postgres:14.4-alpine
+    container_name: g5botdb
+    restart: always
+    networks:
+      - get5
+    environment:
+      - POSTGRES_PASSWORD=
+      - POSTGRES_USER=g5
+      - POSTGRES_DB=g5
+  
+  g5bot:
+    image: ghcr.io/thboss/g5bot:latest
+    restart: always
+    depends_on:
+      - g5botdb
+    container_name: g5bot
+    networks:
+      - get5
+    environment:
+      - SQLUSER=g5
+      - SQLPASSWORD=
+      - DATABASE=g5
+      - SQLHOST=g5botdb
+      - SQLPORT=5432
+      - LANGUAGE=en
+      - PREFIXES=q! Q!
+      - TOKEN=
+      - APIURL=
+      - FRONTENDURL=
+
+networks:
+  get5:
+    external: true


### PR DESCRIPTION
With these changes a user can either build locally using the `docker build -t <user>\g5bot:latest` using `-e` for the environment variables, or alternatively use the docker-compose file and fill out all the fields. Once this complete, the bot and all its dependencies will be installed on two separate containers (bot being one, postgres being the other), and the bot should be up and running in a matter of minutes, without any changes to the host system.