### PR TITLE
fix usernames + add prefix to team names.

### DIFF
--- a/bot/helpers/api.py
+++ b/bot/helpers/api.py
@@ -222,11 +222,11 @@ class APIManager:
         users_model = await db.get_users(users)
         url = "/api/teams"
         data = {
-            'name': name,
+            'name': 'team_' + name,
             'public_team': 0,
             'auth_name': {
                 db_user.steam: {
-                    'name': 'test',
+                    'name': db_user.user.display_name,
                     'captain': index == 0,
                     'coach': False
                 } for index, db_user in enumerate(users_model)


### PR DESCRIPTION
- Fixes player names to use their Discord display name. 

- Adds the `team_` prefix to teams that are created. 


Matches appeared to be 1v1's due to how the names were reported in Discord and on the website.